### PR TITLE
Fix ShareExtension target in Podfile

### DIFF
--- a/share_handler/README.md
+++ b/share_handler/README.md
@@ -136,7 +136,7 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # share_handler addition start
-  target 'Share Extension' do
+  target 'ShareExtension' do
     inherit! :search_paths
     pod "share_handler_ios_models", :path => ".symlinks/plugins/share_handler_ios/ios/Models"
   end


### PR DESCRIPTION
In the second step of the iOS setup, you are writing to create Share Extension called `ShareExtension`, but later in Podfile you are adding the target with space.