### PR TITLE
fix problems receiving files on Android "Android/Files/Recent"

### DIFF
--- a/share_handler_android/android/src/main/kotlin/com/shoutsocial/share_handler/FileDirectory.kt
+++ b/share_handler_android/android/src/main/kotlin/com/shoutsocial/share_handler/FileDirectory.kt
@@ -89,7 +89,7 @@ object FileDirectory {
     private fun getDataColumn(context: Context, uri: Uri, selection: String?,
                               selectionArgs: Array<String>?): String? {
 
-        if (uri.authority != null) {
+        if (uri.authority != null && selection==null) {
             var cursor: Cursor? = null
             val column = "_display_name"
             val projection = arrayOf(column)

--- a/share_handler_android/android/src/main/kotlin/com/shoutsocial/share_handler/FileDirectory.kt
+++ b/share_handler_android/android/src/main/kotlin/com/shoutsocial/share_handler/FileDirectory.kt
@@ -118,7 +118,7 @@ object FileDirectory {
                 val type = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
                 targetFile = File(context.cacheDir, "${prefix}_${Date().time}.$type")
             }
-
+            val uri = selectionArgs?.let { args -> uri.buildUpon().appendPath(args.first()).build() } ?: uri
             context.contentResolver.openInputStream(uri)?.use { input ->
                 FileOutputStream(targetFile).use { fileOut ->
                     input.copyTo(fileOut)


### PR DESCRIPTION
- Android 30 -> 33 : When receiving files on Android at path: `Android/Files/Recent` the application will crash.
- Android 29 -> worked