### PR TITLE
feat: hide the default share modal on iOS

### DIFF
--- a/share_handler/README.md
+++ b/share_handler/README.md
@@ -151,7 +151,7 @@ target 'Runner' do
 end
 ```
 
-7. In Xcode, replace the contents of ShareExtension/ShareViewController.swift with the following code. The share extension doesn't launch a UI of its own, instead it serializes the shared content/media and saves it to the groups shared preferences, then opens a deep link into the full app so your flutter/dart code can then read the serialized data and handle it accordingly. Note that for a brief moment, a default share modal might show up before it redirects to the app (particularly noticeable when using a simulator).
+7. In Xcode, replace the contents of ShareExtension/ShareViewController.swift with the following code. The share extension doesn't launch a UI of its own, instead it serializes the shared content/media and saves it to the groups shared preferences, then opens a deep link into the full app so your flutter/dart code can then read the serialized data and handle it accordingly. 
 
 ```swift
 import share_handler_ios_models

--- a/share_handler_ios/ios/Models/Classes/ShareHandlerIosViewController.swift
+++ b/share_handler_ios/ios/Models/Classes/ShareHandlerIosViewController.swift
@@ -14,7 +14,7 @@ import Contacts
 
 @available(iOS 14.0, *)
 @available(iOSApplicationExtension 14.0, *)
-open class ShareHandlerIosViewController: SLComposeServiceViewController {
+open class ShareHandlerIosViewController: UIViewController {
     static var hostAppBundleIdentifier = ""
     static var appGroupId = ""
     let sharedKey = "ShareKey"
@@ -29,11 +29,6 @@ open class ShareHandlerIosViewController: SLComposeServiceViewController {
     lazy var userDefaults: UserDefaults = {
         return UserDefaults(suiteName: ShareHandlerIosViewController.appGroupId)!
     }()
-    
-    
-    public override func isContentValid() -> Bool {
-        return true
-    }
     
     public func loadIds() {
             // loading Share extension App Id
@@ -55,13 +50,14 @@ open class ShareHandlerIosViewController: SLComposeServiceViewController {
         
         // load group and app id from build info
                 loadIds();
+        Task {
+            await handleInputItems()
+        }
     }
     
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        Task {
-            await handleInputItems()
-        }
+        extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
     }
     
     func handleInputItems() async {
@@ -92,14 +88,6 @@ open class ShareHandlerIosViewController: SLComposeServiceViewController {
             }
             redirectToHostApp()
         }
-    }
-    
-    public override func didSelectPost() {
-        print("didSelectPost");
-    }
-    
-    public override func configurationItems() -> [Any]! {
-        return []
     }
     
     public func getNewFileUrl(fileName: String) -> URL {
@@ -287,7 +275,6 @@ open class ShareHandlerIosViewController: SLComposeServiceViewController {
             }
             responder = responder!.next
         }
-        extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
     }
     
     enum RedirectType {


### PR DESCRIPTION
This PR fixes #49 

1. With `UIViewController` the default modal won't appear, only zoom will be seen.

2. Put the main handler method in the `viewDidLoad` so that the share extension will go to our app immediately without showing the default share modal, then the behavior in 1 won't be seen.