### PR TITLE
fix: UIApplication.openURL is deprecated

### DIFF
--- a/share_handler_ios/ios/Models/Classes/ShareHandlerIosViewController.swift
+++ b/share_handler_ios/ios/Models/Classes/ShareHandlerIosViewController.swift
@@ -270,8 +270,9 @@ open class ShareHandlerIosViewController: UIViewController {
         userDefaults.synchronize()
         
         while (responder != nil) {
-            if (responder?.responds(to: selectorOpenURL))! {
-                let _ = responder?.perform(selectorOpenURL, with: url)
+            if let application = responder as? UIApplication {
+                application.open(url!, options: [:], completionHandler: nil)
+                break
             }
             responder = responder!.next
         }


### PR DESCRIPTION
Quick fix to resolve: The caller of UIApplication.openURL(_:) needs to migrate to the non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO).

Resolves: https://github.com/ShoutSocial/share_handler/issues/96