### PR TITLE
Fix sharing not working on iOS 18

### DIFF
--- a/share_handler_ios/ios/Models/Classes/ShareHandlerIosViewController.swift
+++ b/share_handler_ios/ios/Models/Classes/ShareHandlerIosViewController.swift
@@ -272,10 +272,13 @@ open class ShareHandlerIosViewController: UIViewController {
 
         while (responder != nil) {
             if let application = responder as? UIApplication {
-                application.open(url!, options: [:], completionHandler: nil)
-                break
+                if #available(iOS 18.0, *) {
+                    let _ = application.open(url!, options: [:], completionHandler: nil)
+                } else {
+                    let _ = application.perform(selectorOpenURL, with: url)
+                }
             }
-            responder = responder!.next
+            responder = responder?.next
         }
     }
 


### PR DESCRIPTION
On the latest version, the library does not work on iOS 18 as discussed [here](https://github.com/ShoutSocial/share_handler/issues/102). This pull requests updates the `ShareHandlerIosViewController` to fix this issue while maintaining compatibility with older versions of iOS. Until this PR is merged, it can be tested by updating your `pubspec.yaml` to include the following:

```
dependency_overrides:
  share_handler_ios:
    git:
      url: https://github.com/gaucidaniel/share_handler.git
      path: share_handler_ios
      ref: main
```