### PR TITLE
Remove Intent.ACTION_VIEW handling

### DIFF
--- a/share_handler_android/android/src/main/kotlin/com/shoutsocial/share_handler/ShareHandlerPlugin.kt
+++ b/share_handler_android/android/src/main/kotlin/com/shoutsocial/share_handler/ShareHandlerPlugin.kt
@@ -96,9 +96,6 @@ class ShareHandlerPlugin : FlutterPlugin, Messages.ShareHandlerApi, EventChannel
       action = Intent.ACTION_SEND
       putExtra("conversationIdentifier", media.conversationIdentifier)
     }
-//    val intent = Intent(Intent.ACTION_VIEW).apply {
-//      putExtra("conversationIdentifier", media.conversationIdentifier)
-//    }
     val shortcutTarget = "$packageName.dynamic_share_target"
     val shortcutBuilder = ShortcutInfoCompat.Builder(applicationContext, media.conversationIdentifier ?: "")
       .setShortLabel(media.speakableGroupName ?: "Unknown")
@@ -172,7 +169,6 @@ class ShareHandlerPlugin : FlutterPlugin, Messages.ShareHandlerApi, EventChannel
 
     val text: String? = when (intent.action) {
       Intent.ACTION_SEND, Intent.ACTION_SEND_MULTIPLE -> intent.getStringExtra(Intent.EXTRA_TEXT)
-      Intent.ACTION_VIEW -> intent.dataString
       else -> null
     }
 


### PR DESCRIPTION
ACTION_VIEW is not meant for sharing: it's meant for deep links. The [documentation for receiving share intents][1] only mentions ACTION_SEND and ACTION_SEND_MULTIPLE.

share_handler should only handle share intents, to avoid conflicts with other packages handling deep links (e.g. app_links).

[1]: https://developer.android.com/training/sharing/receive

Closes: https://github.com/ShoutSocial/share_handler/issues/86