### PR TITLE
Remove READ_EXTERNAL_STORAGE permission declaration from README.md

### DIFF
--- a/share_handler/README.md
+++ b/share_handler/README.md
@@ -167,7 +167,6 @@ class ShareViewController: ShareHandlerIosViewController {}
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 .....
  >
- <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
   <application
         android:name="io.flutter.app.FlutterApplication"


### PR DESCRIPTION
The receiving app does not require any additional permissions to read the incoming data, because Android grants the permissions automatically as stated in https://developer.android.com/training/sharing/send#send-binary-content & https://developer.android.com/training/sharing/receive.

READ_EXTERNAL_STORAGE is no-op in Android SDK >= 33 anyways (https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE)