### PR TITLE
Use Flutter's preferred Android compileSdkVersion

### DIFF
--- a/share_handler_android/android/build.gradle
+++ b/share_handler_android/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace "com.shoutsocial.share_handler"
-    compileSdkVersion 34
+    compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Avoid relying on an old Android SDK for compiling the package.

Flutter's preferred compileSdkVersion is higher than 34: https://github.com/flutter/flutter/blob/d93e2d4b82ba2cc1b730948a81f823d52374d5dc/packages/flutter_tools/lib/src/android/gradle_utils.dart#L52